### PR TITLE
Package rocq-candy.0.2.0

### DIFF
--- a/packages/rocq-candy/rocq-candy.0.2.0/opam
+++ b/packages/rocq-candy/rocq-candy.0.2.0/opam
@@ -1,0 +1,37 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/rocq-candy"
+dev-repo: "git+https://github.com/ku-sldg/rocq-candy.git"
+bug-reports: "https://github.com/ku-sldg/rocq-candy/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Snippets of nice and useful (maybe even yummy) Rocq code"
+description: """
+<Project Description>"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "coq-ext-lib" { >= "0.13.0" }
+]
+
+tags: [
+  "logpath:rocq-candy"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/rocq-candy/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=8ce03866f4e7fce007f54763c1f1e1af"
+    "sha512=516efcef3371ff892aba7b75f08355f59157b57280c43ea085581d19249c9952ae810c69857e5d47fb610b6053bb2152453561f2258ec41e983377fb74c55f24"
+  ]
+}


### PR DESCRIPTION
### `rocq-candy.0.2.0`
Snippets of nice and useful (maybe even yummy) Rocq code
<Project Description>



---
* Homepage: https://github.com/ku-sldg/rocq-candy
* Source repo: git+https://github.com/ku-sldg/rocq-candy.git
* Bug tracker: https://github.com/ku-sldg/rocq-candy/issues

---
:camel: Pull-request generated by opam-publish v2.5.0