### PR TITLE
Package coq-EasyBakeCakeML.0.1.0

### DIFF
--- a/packages/coq-EasyBakeCakeML/coq-EasyBakeCakeML.0.1.0/opam
+++ b/packages/coq-EasyBakeCakeML/coq-EasyBakeCakeML.0.1.0/opam
@@ -1,0 +1,39 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/Durbatuluk1701/EasyBakeCakeML"
+dev-repo: "git+https://github.com/Durbatuluk1701/EasyBakeCakeML.git"
+bug-reports: "https://github.com/Durbatuluk1701/EasyBakeCakeML/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "An extraction plugin for CakeML"
+description: """
+An extraction plugin for CakeML that does not require any semantic preservation proofs."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.13~" }
+  "dune" {>= "3.17"}
+  "coq" 
+]
+
+tags: [
+  "keyword:CakeML"
+  "keyword:Extraction"
+  "logpath:EasyBakeCakeML"
+]
+authors: [
+  "TJ Barclay"
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/Durbatuluk1701/EasyBakeCakeML/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=2db5a3fc85b54c446520e74384e4f801"
+    "sha512=4371c2085c3b2e4036a480fdce2dda244a9eccef39961663b10f2aa3d5495ba5c4dafb3e3b7896300da047714dd9a660a8f2dbb1531e2a9f7b4bdcab941a9257"
+  ]
+}


### PR DESCRIPTION
### `coq-EasyBakeCakeML.0.1.0`
An extraction plugin for CakeML
An extraction plugin for CakeML that does not require any semantic preservation proofs.



---
* Homepage: https://github.com/Durbatuluk1701/EasyBakeCakeML
* Source repo: git+https://github.com/Durbatuluk1701/EasyBakeCakeML.git
* Bug tracker: https://github.com/Durbatuluk1701/EasyBakeCakeML/issues

---
:camel: Pull-request generated by opam-publish v2.5.0