### PR TITLE
Package coq-copland-spec.0.1.1

### DIFF
--- a/packages/coq-copland-spec/coq-copland-spec.0.1.1/opam
+++ b/packages/coq-copland-spec/coq-copland-spec.0.1.1/opam
@@ -1,0 +1,41 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-spec"
+dev-repo: "git+https://github.com/ku-sldg/copland-spec.git"
+bug-reports: "https://github.com/ku-sldg/copland-spec/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Specification for the Copland DSL for Attestation Protocols"
+description: """
+Specification for the Copland DSL for Attestation Protocols"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.2" }
+  "coq-json" { >= "0.2.0" }
+  "coq-ext-lib" { >= "0.13.0" }
+]
+
+tags: [
+  "logpath:copland-spec"
+]
+authors: [
+  "Adam Petz <ampetz@ku.edu>"
+  "Will Thomas <30wthomas@ku.edu>"
+  "KU-SLDG Lab"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-spec/archive/refs/tags/v0.1.1.tar.gz"
+  checksum: [
+    "md5=fec6a8ca0c1773f1d6649c170db525c2"
+    "sha512=69f0447c6c0794ddedd6ec2396a1f0f37aff7794a8e23f579e6aad7f9d4c8c3b2fc0f42102ff4eb198f93e68689c0f0a0ae358f7d082a0a13bab4ba09ace1d8f"
+  ]
+}


### PR DESCRIPTION
### `coq-copland-spec.0.1.1`
Specification for the Copland DSL for Attestation Protocols
Specification for the Copland DSL for Attestation Protocols



---
* Homepage: https://github.com/ku-sldg/copland-spec
* Source repo: git+https://github.com/ku-sldg/copland-spec.git
* Bug tracker: https://github.com/ku-sldg/copland-spec/issues

---
:camel: Pull-request generated by opam-publish v2.5.0