### PR TITLE
Package coq-EasyBakeCakeML.0.2.0

### DIFF
--- a/packages/coq-EasyBakeCakeML/coq-EasyBakeCakeML.0.2.0/opam
+++ b/packages/coq-EasyBakeCakeML/coq-EasyBakeCakeML.0.2.0/opam
@@ -1,0 +1,39 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/Durbatuluk1701/EasyBakeCakeML"
+dev-repo: "git+https://github.com/Durbatuluk1701/EasyBakeCakeML.git"
+bug-reports: "https://github.com/Durbatuluk1701/EasyBakeCakeML/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "An extraction plugin for CakeML"
+description: """
+An extraction plugin for CakeML that does not require any semantic preservation proofs."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.13~" }
+  "dune" {>= "3.17"}
+  "coq" 
+]
+
+tags: [
+  "keyword:CakeML"
+  "keyword:Extraction"
+  "logpath:EasyBakeCakeML"
+]
+authors: [
+  "TJ Barclay"
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/Durbatuluk1701/EasyBakeCakeML/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=a3f5c1c874d73dbb9cbee6a569a5d186"
+    "sha512=5796e6b5938375f5d376a2d55d93392071039aa0a53e0d72f1303053dbe3e761ceac78148ba5b6de208b3da3bcf858f6a6df27139d54743c62a5f37f1d77f2c1"
+  ]
+}


### PR DESCRIPTION
### `coq-EasyBakeCakeML.0.2.0`
An extraction plugin for CakeML
An extraction plugin for CakeML that does not require any semantic preservation proofs.



---
* Homepage: https://github.com/Durbatuluk1701/EasyBakeCakeML
* Source repo: git+https://github.com/Durbatuluk1701/EasyBakeCakeML.git
* Bug tracker: https://github.com/Durbatuluk1701/EasyBakeCakeML/issues

---
:camel: Pull-request generated by opam-publish v2.5.0