### PR TITLE
Package rocq-candy.0.3.0

### DIFF
--- a/packages/rocq-candy/rocq-candy.0.3.0/opam
+++ b/packages/rocq-candy/rocq-candy.0.3.0/opam
@@ -1,0 +1,36 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/rocq-candy"
+dev-repo: "git+https://github.com/ku-sldg/rocq-candy.git"
+bug-reports: "https://github.com/ku-sldg/rocq-candy/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Snippets of nice and useful Rocq code utilized by the KU-SLDG Lab"
+description: """
+This library contains snippets of nice and useful Rocq code utilized by the KU-SLDG Lab. It is not intended to be a full-fledged library, but rather a collection of useful code that can be shared between projects."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+]
+
+tags: [
+  "logpath:rocq-candy"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/rocq-candy/archive/refs/tags/v0.3.0.tar.gz"
+  checksum: [
+    "md5=46f0b2935a21534da6198f0a5f26b3a2"
+    "sha512=10a58b0b19610628f5e704ac12de4874c08d469650a0db525ab4feb5ab536271eb83526752eb616a1a52a859d08efe7c6f783cd7ebe783df2973fa85fc7f1875"
+  ]
+}


### PR DESCRIPTION
### `rocq-candy.0.3.0`
Snippets of nice and useful Rocq code utilized by the KU-SLDG Lab
This library contains snippets of nice and useful Rocq code utilized by the KU-SLDG Lab. It is not intended to be a full-fledged library, but rather a collection of useful code that can be shared between projects.



---
* Homepage: https://github.com/ku-sldg/rocq-candy
* Source repo: git+https://github.com/ku-sldg/rocq-candy.git
* Bug tracker: https://github.com/ku-sldg/rocq-candy/issues

---
:camel: Pull-request generated by opam-publish v2.5.0