### PR TITLE
Package rocq-copland-manifest-tools.0.2.0

### DIFF
--- a/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.0/opam
+++ b/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.0/opam
@@ -1,0 +1,40 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-manifest-tools"
+dev-repo: "git+https://github.com/ku-sldg/copland-manifest-tools.git"
+bug-reports: "https://github.com/ku-sldg/copland-manifest-tools/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Copland Manifest definitions and tools built in Rocq"
+description: """
+This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.1" }
+  "rocq-copland-spec" { >= "0.1.0" }
+  "rocq-cli-tools" { >= "0.1.0" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+]
+
+tags: [
+  "logpath:copland-manifest-tools"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-manifest-tools/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=31e3272c30fdb70d45c1fa24076ed7d0"
+    "sha512=2001b1172b17b02ae65806676ab928ef569cc1571fab0a410fbebbf05e9d9e48873c4fbfa46ade6c95582fd7ce7218a8c6b639604115954cc5d929bfdcd8fe10"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-manifest-tools.0.2.0`
Copland Manifest definitions and tools built in Rocq
This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality.



---
* Homepage: https://github.com/ku-sldg/copland-manifest-tools
* Source repo: git+https://github.com/ku-sldg/copland-manifest-tools.git
* Bug tracker: https://github.com/ku-sldg/copland-manifest-tools/issues

---
:camel: Pull-request generated by opam-publish v2.5.0