### PR TITLE
Package rocq-copland-manifest-tools.0.2.2

### DIFF
--- a/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.2/opam
+++ b/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.2/opam
@@ -1,0 +1,40 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-manifest-tools"
+dev-repo: "git+https://github.com/ku-sldg/copland-manifest-tools.git"
+bug-reports: "https://github.com/ku-sldg/copland-manifest-tools/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Copland Manifest definitions and tools built in Rocq"
+description: """
+This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.1" }
+  "rocq-copland-spec" { >= "0.1.0" }
+  "rocq-cli-tools" { >= "0.1.0" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+]
+
+tags: [
+  "logpath:copland-manifest-tools"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-manifest-tools/archive/refs/tags/v0.2.2.tar.gz"
+  checksum: [
+    "md5=bb28fbfb15513c9d093c969b90fb5d68"
+    "sha512=bf75f3e266c5093f6c2ed2c2719c6ea008db4fb39926ab3360e49957cf7b55f08a94c84d61da284e801a2dce737e0a8c2c8af0af828ec68e23fcfa6d0e7a97c7"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-manifest-tools.0.2.2`
Copland Manifest definitions and tools built in Rocq
This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality.



---
* Homepage: https://github.com/ku-sldg/copland-manifest-tools
* Source repo: git+https://github.com/ku-sldg/copland-manifest-tools.git
* Bug tracker: https://github.com/ku-sldg/copland-manifest-tools/issues

---
:camel: Pull-request generated by opam-publish v2.5.0