### PR TITLE
Package rocq-copland-manifest-tools.0.2.3

### DIFF
--- a/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.3/opam
+++ b/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.2.3/opam
@@ -1,0 +1,40 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-manifest-tools"
+dev-repo: "git+https://github.com/ku-sldg/copland-manifest-tools.git"
+bug-reports: "https://github.com/ku-sldg/copland-manifest-tools/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Copland Manifest definitions and tools built in Rocq"
+description: """
+This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.1" }
+  "rocq-copland-spec" { >= "0.1.0" }
+  "rocq-cli-tools" { >= "0.1.0" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+]
+
+tags: [
+  "logpath:copland-manifest-tools"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-manifest-tools/archive/refs/tags/v0.2.3.tar.gz"
+  checksum: [
+    "md5=b56c67f8d0f8897f72ab0d6afb1135b7"
+    "sha512=52f12f472600c37a3c9a7b4302c711f669c95bb688816169105de9af13b4cb21f3c7d57463f504f8c6c6757e50377b6d343fd57dda8295f57c434f29bdedc10a"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-manifest-tools.0.2.3`
Copland Manifest definitions and tools built in Rocq
This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality.



---
* Homepage: https://github.com/ku-sldg/copland-manifest-tools
* Source repo: git+https://github.com/ku-sldg/copland-manifest-tools.git
* Bug tracker: https://github.com/ku-sldg/copland-manifest-tools/issues

---
:camel: Pull-request generated by opam-publish v2.5.0