### PR TITLE
Package rocq-cvm.0.1.0

### DIFF
--- a/packages/rocq-cvm/rocq-cvm.0.1.0/opam
+++ b/packages/rocq-cvm/rocq-cvm.0.1.0/opam
@@ -1,0 +1,50 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/cvm"
+dev-repo: "git+https://github.com/ku-sldg/cvm.git"
+bug-reports: "https://github.com/ku-sldg/cvm/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "The Copland Virtual Machine (CVM)"
+description: """
+The Copland Virtual Machine (CVM) is a Rocq library that formalizes a virtual machine for the Copland Domain Specific Language for layered remote attestation."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.1" }
+  "rocq-copland-spec" { >= "0.1.1" }
+  "rocq-copland-manifest-tools" { >= "0.2.4" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+  "bake" { >= "1.2.1" }
+  "conf-zmq" { >= "0.1" }
+]
+
+tags: [
+  "logpath:cvm"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+
+depexts: [
+  ["libzmq3-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["zeromq"] {os-distribution = "arch" | os-distribution = "nixos"}
+  ["zeromq"] {os-distribution = "homebrew" & os = "macos"}
+  ["zeromq-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "opensuse" | os-distribution = "rhel"}
+  ["zeromq-dev"] {os-distribution = "alpine"}
+  ["cygwin-devel" "libzmq-devel"] {os-distribution = "cygwin"}
+]
+url {
+  src: "https://github.com/ku-sldg/cvm/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4a7fbe487aaa1546e37206da22d24cca"
+    "sha512=537966891b96ac02bd0b60444547dd677399a3548c31b95cbc9af39a947aa1e092a84e670c087df75055e78a7341b0a2f2ada2a5c678fd0c1b3592168fb158b8"
+  ]
+}


### PR DESCRIPTION
### `rocq-cvm.0.1.0`
The Copland Virtual Machine (CVM)
The Copland Virtual Machine (CVM) is a Rocq library that formalizes a virtual machine for the Copland Domain Specific Language for layered remote attestation.



---
* Homepage: https://github.com/ku-sldg/cvm
* Source repo: git+https://github.com/ku-sldg/cvm.git
* Bug tracker: https://github.com/ku-sldg/cvm/issues

---
:camel: Pull-request generated by opam-publish v2.5.0