### PR TITLE
Package rocq-copland-spec.0.3.0

### DIFF
--- a/packages/rocq-copland-spec/rocq-copland-spec.0.3.0/opam
+++ b/packages/rocq-copland-spec/rocq-copland-spec.0.3.0/opam
@@ -1,0 +1,40 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-spec"
+dev-repo: "git+https://github.com/ku-sldg/copland-spec.git"
+bug-reports: "https://github.com/ku-sldg/copland-spec/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Specification for the Copland DSL for Attestation Protocols"
+description: """
+Specification for the Copland DSL for Attestation Protocols"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.2" }
+  "rocq-json" { >= "0.2.0" }
+]
+
+tags: [
+  "logpath:copland-spec"
+]
+authors: [
+  "Adam Petz <ampetz@ku.edu>"
+  "Will Thomas <30wthomas@ku.edu>"
+  "KU-SLDG Lab"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-spec/archive/refs/tags/v0.3.0.tar.gz"
+  checksum: [
+    "md5=e0f30b921969ee85c511f5c856b2995a"
+    "sha512=2aac88950f6b583d3000b1b16b30a7a2d47562ede31b88767b2b7c32a1a849d3030b96ca04c92ce6c3df230f1815b54552b598cf44ad347ba09f5022fd59f326"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-spec.0.3.0`
Specification for the Copland DSL for Attestation Protocols
Specification for the Copland DSL for Attestation Protocols



---
* Homepage: https://github.com/ku-sldg/copland-spec
* Source repo: git+https://github.com/ku-sldg/copland-spec.git
* Bug tracker: https://github.com/ku-sldg/copland-spec/issues

---
:camel: Pull-request generated by opam-publish v2.5.0