### PR TITLE
Package rocq-logging.0.1.2

### DIFF
--- a/packages/rocq-logging/rocq-logging.0.1.2/opam
+++ b/packages/rocq-logging/rocq-logging.0.1.2/opam
@@ -1,0 +1,38 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/rocq-logging"
+dev-repo: "git+https://github.com/ku-sldg/rocq-logging.git"
+bug-reports: "https://github.com/ku-sldg/rocq-logging/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "A logging library for Rocq"
+description: """
+This library provides logging utilities for Rocq, as well as methods for natively extracting logging events from Rocq code to a target language."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.2.1" }
+  "rocq-EasyBakeCakeML" { >= "0.4.0" }
+]
+
+tags: [
+  "logpath:rocq-logging"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/rocq-logging/archive/refs/tags/v0.1.2.tar.gz"
+  checksum: [
+    "md5=fe670b4001bd413970cfa437a470e38b"
+    "sha512=94885db0f048419c253b6dac770e0e27fa0095e532ec2ea064ad43b1d85003e0e1d9f67411c5068513703c7e45086d579cfd3deb636db655d7b0da68ad5a59bf"
+  ]
+}


### PR DESCRIPTION
### `rocq-logging.0.1.2`
A logging library for Rocq
This library provides logging utilities for Rocq, as well as methods for natively extracting logging events from Rocq code to a target language.



---
* Homepage: https://github.com/ku-sldg/rocq-logging
* Source repo: git+https://github.com/ku-sldg/rocq-logging.git
* Bug tracker: https://github.com/ku-sldg/rocq-logging/issues

---
:camel: Pull-request generated by opam-publish v2.5.1