### PR TITLE
Package rocq-copland-manifest-tools.0.6.0

### DIFF
--- a/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.6.0/opam
+++ b/packages/rocq-copland-manifest-tools/rocq-copland-manifest-tools.0.6.0/opam
@@ -1,0 +1,41 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-manifest-tools"
+dev-repo: "git+https://github.com/ku-sldg/copland-manifest-tools.git"
+bug-reports: "https://github.com/ku-sldg/copland-manifest-tools/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Copland Manifest definitions and tools built in Rocq"
+description: """
+This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.6.0" }
+  "rocq-copland-spec" { >= "0.6.0" }
+  "rocq-cli-tools" { >= "0.1.0" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+  "bake" { >= "0.1.0" }
+]
+
+tags: [
+  "logpath:copland-manifest-tools"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-manifest-tools/archive/refs/tags/v0.6.0.tar.gz"
+  checksum: [
+    "md5=ade28c987065d9a0402975a7eba7dbe6"
+    "sha512=d5e869f0cdedf937ef456db8736bdbae5463ddfbceae3270b40bb1d8c8ba12496531ae77060d2cae93de19086c57d3ccbe2e842400a5924abaa4f59dfd5012f0"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-manifest-tools.0.6.0`
Copland Manifest definitions and tools built in Rocq
This library provides definitions and tools for working with Copland manifests in Rocq. It includes utilities for validating, generating, and manipulating manifests, as well as providing a framework for building and extending manifest-related functionality.



---
* Homepage: https://github.com/ku-sldg/copland-manifest-tools
* Source repo: git+https://github.com/ku-sldg/copland-manifest-tools.git
* Bug tracker: https://github.com/ku-sldg/copland-manifest-tools/issues

---
:camel: Pull-request generated by opam-publish v2.7.0