### PR TITLE
Package rocq-copland-evidence-tools.0.6.0

### DIFF
--- a/packages/rocq-copland-evidence-tools/rocq-copland-evidence-tools.0.6.0/opam
+++ b/packages/rocq-copland-evidence-tools/rocq-copland-evidence-tools.0.6.0/opam
@@ -1,0 +1,42 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "30wthomas@ku.edu"
+
+homepage: "https://github.com/ku-sldg/copland-evidence-tools"
+dev-repo: "git+https://github.com/ku-sldg/copland-evidence-tools.git"
+bug-reports: "https://github.com/ku-sldg/copland-evidence-tools/issues"
+license: "CC-BY-SA-4.0"
+
+synopsis: "Tools for working with evidence in the Copland language"
+description: """
+This project provides tools and libraries for working with evidence in the Copland programming language."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" { >= "4.12~" }
+  "dune" {>= "3.17"}
+  "coq" 
+  "rocq-candy" { >= "0.6.0" }
+  "rocq-cli-tools" { >= "0.2.0" }
+  "rocq-json" { >= "0.6.0" }
+  "rocq-copland-spec" { >= "0.6.0" }
+  "bake" { >= "0.1.0" }
+  "rocq-EasyBakeCakeML" { >= "0.5.0" }
+]
+
+tags: [
+  "logpath:copland-evidence-tools"
+]
+authors: [
+  "Will Thomas <30wthomas@ku.edu>"
+]
+url {
+  src:
+    "https://github.com/ku-sldg/copland-evidence-tools/archive/refs/tags/v0.6.0.tar.gz"
+  checksum: [
+    "md5=e3715cd1ef294acea711be856944eea8"
+    "sha512=68143ab0001a9d1837d0b3377de6ed0c5927aac4e075a417b0edf9616b5c97d2f9b2b76bd3bd9b9fe3bdeeb1a8564cd7f31ab185f7f486bffe0ff5df7f37da4f"
+  ]
+}


### PR DESCRIPTION
### `rocq-copland-evidence-tools.0.6.0`
Tools for working with evidence in the Copland language
This project provides tools and libraries for working with evidence in the Copland programming language.



---
* Homepage: https://github.com/ku-sldg/copland-evidence-tools
* Source repo: git+https://github.com/ku-sldg/copland-evidence-tools.git
* Bug tracker: https://github.com/ku-sldg/copland-evidence-tools/issues

---
:camel: Pull-request generated by opam-publish v2.7.0